### PR TITLE
Correctly handle keys that point to a different subtree

### DIFF
--- a/lib/uri.js
+++ b/lib/uri.js
@@ -6,7 +6,9 @@ function addDirectoryUriProperty(parentUrl, directory) {
     if (parentUrl[parentUrl.length - 1] !== '/') {
         parentUrl += '/';
     }
-
+    if (directory.key[0] === '/') {
+        parentUrl = '';
+    }
     directory.uri = parentUrl + directory.key;
 }
 

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -68,6 +68,12 @@ describe('query()', function() {
 				expect(result._children[0].uri).to.be('/library/sections/1');
 			});
 		});
+
+		it('should use the key as the uri if the key is a root-relative path', function() {
+			return api.query('/library/sections/1/all').then(function(result) {
+				expect(result._children[0].uri).to.be(result._children[0].key);
+			});
+		});
 	});
 
 	describe('Server URI', function() {

--- a/test/samples/library/sections/1/all.json
+++ b/test/samples/library/sections/1/all.json
@@ -1,0 +1,17 @@
+{ "_elementType":"MediaContainer",
+  "librarySectionID":"1",
+  "librarySectionTitle":"Misc",
+  "nocache":"1",
+  "thumb":"/:/resources/show.png",
+  "title1":"Misc",
+  "title2":"All Shows",
+  "viewGroup":"show",
+  "_children":[{
+    "_elementType":"Directory",
+    "key":"/library/metadata/9901/children",
+    "type":"show",
+    "title":"The Sample Show",
+    "summary":"This is an example show."
+  }
+]}
+


### PR DESCRIPTION
This prevents creating uris like `/library/sections/9/all//library/metadata/31032/children`, which is what you get as the `.uri` for TV shows in a shows section.  (That is, querying `/library/sections/N/all` will give you broken child URIs at the moment.)