### PR TITLE
Change xml2json to xml2js

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -2,7 +2,7 @@ var uuid = require('uuid');
 var url = require('url');
 var request = require('request');
 var Q = require('q');
-var xml2json = require('xml2json');
+var xml2js = require('xml2js');
 
 var uri = require('./uri');
 var auth = require('./auth');
@@ -122,7 +122,7 @@ PlexAPI.prototype._request = function _request(relativeUrl, method, parseRespons
                 return deferred.resolve(JSON.parse(body.toString('utf8')));
             }
             if (response.headers['content-type'].indexOf('xml') > -1) {
-                return deferred.resolve(xml2json.toJson(body.toString('utf8'), {
+                return deferred.resolve(xml2js.parseString(body.toString('utf8'), {
                     object: true
                 }));
             }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "q": "^1.0.1",
     "request": "^2.36.0",
     "uuid": "^2.0.1",
-    "xml2json": "^0.6.2"
+    "xml2js": "^0.4.9"
   },
   "devDependencies": {
     "expect.js": "*",


### PR DESCRIPTION
Moves from a library requiring compiling to a native javascript library, which is a tad easier for remote deploying in some circumstances. Also decreases the dependency footprint.