### PR TITLE
(don't merge) Proof of concept for authenticating using a PIN, like the official Plex clients do

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,6 +2,9 @@ var request = require('request');
 var Q = require('q');
 
 var rxAuthToken = /authenticationToken="([^"]+)"/;
+var rxPinCode = /<code>([A-Z0-9]+)<\/code>/i;
+var rxPinID = /<id type="integer">([0-9]+)<\/id>/i;
+var rxAuthTokenFromPin = /<auth_token>([0-9A-Z]+)<\/auth_token>/i;
 
 function authHeaderVal(username, password) {
     var authString = username + ':' + password;
@@ -38,6 +41,63 @@ function requestSignIn(username, password, headers) {
     return deferred.promise;
 }
 
+function requestPin(headers) {
+    var deferred = Q.defer();
+    var options = {
+        url: 'https://plex.tv/pins.xml',
+        headers: {
+            'X-Plex-Client-Identifier': headers.identifier,
+            'X-Plex-Product': headers.product,
+            'X-Plex-Version': headers.version,
+            'X-Plex-Device': headers.device,
+            'X-Plex-Device-Name': headers.deviceName,
+            'X-Plex-Platform': headers.platform,
+            'X-Plex-Platform-Version': headers.platformVersion,
+            'X-Plex-Provides': 'controller'
+        }
+    };
+    request.post(options, function(err, res, xmlBody) {
+        if (err) {
+            return deferred.reject(new Error('Error while requesting https://plex.tv for authentication: ' + String(err)));
+        }
+        if (res.statusCode !== 201) {
+            return deferred.reject(new Error('Invalid status code in authentication response from Plex.tv, expected 201 but got ' + res.statusCode));
+        }
+        deferred.resolve(xmlBody);
+    });
+
+    return deferred.promise;
+}
+
+function requestAuthFromPin(pin, headers) {
+    var deferred = Q.defer();
+    var options = {
+        url: 'https://plex.tv/pins/' + pin + '.xml',
+        headers: {
+            'X-Plex-Client-Identifier': headers.identifier,
+            'X-Plex-Product': headers.product,
+            'X-Plex-Version': headers.version,
+            'X-Plex-Device': headers.device,
+            'X-Plex-Device-Name': headers.deviceName,
+            'X-Plex-Platform': headers.platform,
+            'X-Plex-Platform-Version': headers.platformVersion,
+            'X-Plex-Provides': 'controller'
+        }
+    };
+    console.log(options);
+    request.get(options, function(err, res, xmlBody) {
+        if (err) {
+            return deferred.reject(new Error('Error while requesting https://plex.tv for authentication: ' + String(err)));
+        }
+        if (res.statusCode !== 200) {
+            return deferred.reject(new Error('Invalid status code in authentication response from Plex.tv, expected 201 but got ' + res.statusCode));
+        }
+        deferred.resolve(xmlBody);
+    });
+
+    return deferred.promise;
+}
+
 function extractAuthToken(xmlBody) {
     var tokenMatches = xmlBody.match(rxAuthToken);
     if (!tokenMatches) {
@@ -46,6 +106,40 @@ function extractAuthToken(xmlBody) {
     return tokenMatches[1];
 }
 
+function extractAuthTokenFromPin(xmlBody) {
+    var tokenMatches = xmlBody.match(rxAuthTokenFromPin);
+    if (!tokenMatches) {
+        throw new Error('Couldnt not find authentication token in the Pin response from Plex.tv');
+    }
+    return tokenMatches[1];
+}
+
+// TODO these should maybe use an XML parser rather than re? re works fine, so maybe not.
+function extractAuthPin(xmlBody) {
+    var pinCodeMatches = xmlBody.match(rxPinCode);
+    if (!pinCodeMatches) {
+        throw new Error('Couldnt not find Pin Code response from Plex.tv :(');
+    }
+
+    var pinIdMatches = xmlBody.match(rxPinID);
+    if (!pinIdMatches) {
+        throw new Error('Couldnt not find Pin ID in response from Plex.tv :(');
+    }
+
+    return {
+        code: pinCodeMatches[1],
+        id: pinIdMatches[1]
+    }
+}
+
 exports.retrieveAuthToken = function retrieveAuthToken(username, password, options) {
     return requestSignIn(username, password, options).then(extractAuthToken);
+};
+
+exports.retrieveAuthPin = function retrieveAuthPin(options) {
+    return requestPin(options).then(extractAuthPin);
+};
+
+exports.retrieveAuthTokenFromPin = function retrieveAuthTokenFromPin(pin, options) {
+    return requestAuthFromPin(pin, options).then(extractAuthTokenFromPin);
 };


### PR DESCRIPTION
Opening this PR to discuss how this proof of concept should be implemented as an actual feature.

I managed to get PIN-based authentication working, which works like this from the user's perspective:
1. The code requests a PIN from plex.tv, which is displayed to the user
2. The user enters the PIN to plex.tv via their web browser within a few minutes
3. The code repeatedly asks plex.tv if the PIN has been entered yet, and when it has, it gets an auth token in response. That auth token can now be used to access the user's account.

There are two new API calls that support this: one to request the PIN, and another that you can hit repeatedly to find out if the PIN has been entered yet. (side note: this second request becomes a 404 when the pin expires)

To do a proof of concept, I just slapped some stuff in to the auth.js submodule and then wrote a little test script that included this submodule directly.

I am opening this PR to get feedback on where we think the best place for this feature to actually live. It could potentially even be an entirely different plugin module to node-plex-api, but I'm not sure that's the best way to go.

The immediate challenges I see are:
1. Right now, all auth stuff in node-plex-api is completely invisible to the user-developer. It simply gets a token if it gets a 401, and the developer is none-the-wiser. This new feature by its nature requires the auth stuff to be a little more controllable, and therefore shoving it in to an inaccessible submodule is very likely not the way to go.
2. Right now node-plex-api is a very light wrapper for the plex API. The developer still has to form all of the URLs and do most of the work himself. This code abstracts the PIN process a lot more, (like the current auth code does) and therefore I see it as a bit of a disconnect from the way the rest of the module functions. This may not be an issue, but it's worth considering...