### PR TITLE
Fix authentication by providing plex-api instance to authenticator.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -150,7 +150,7 @@ PlexAPI.prototype._authenticate = function _authenticate() {
         return deferred.reject(new Error('Permission denied even after attempted authentication :( Wrong username and/or password maybe?'));
     }
 
-    this.authenticator.authenticate(this.options, function(err, token) {
+    this.authenticator.authenticate(this, function(err, token) {
         if (err) {
             return deferred.reject(new Error('Authentication failed, reason: ' + err.message));
         }

--- a/test/authenticator-test.js
+++ b/test/authenticator-test.js
@@ -73,7 +73,7 @@ describe('Authenticator', function() {
             });
 
             return api.query(ROOT_URL).then(function () {
-                assert(authenticatorStub.calledOnce, 'authenticator was called');
+                assert(authenticatorStub.firstCall.calledWith(api), 'authenticator was called');
             });
         });
 


### PR DESCRIPTION
Blooper introduced in v3.0.0 when doing authenticator refactoring.

Closes #14.