### PR TITLE
Add support for `https` parameter to force https even on non-443 port

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,8 @@ The parameter can be a string representing the server's hostname, or an object w
 
 Options:
 - **hostname**: hostname where Plex Server runs
-- **port**: port number Plex Server is listening on (optional, default: 32400)
+- **port**: port number Plex Server is listening on (optional, default: `32400`)
+- **https**: (optional, default: `false`)
 - **username**: plex.tv username (optional / required for PlexHome)
 - **password**: plex.tv password (optional / required for PlexHome)
 - **token**: plex.tv authentication token (optional)

--- a/lib/api.js
+++ b/lib/api.js
@@ -18,6 +18,7 @@ function PlexAPI(options, deprecatedPort) {
 
     this.hostname = hostname;
     this.port = deprecatedPort || opts.port || PLEX_SERVER_PORT;
+    this.https = opts.https || false;
     this.username = opts.username;
     this.password = opts.password;
     this.authToken = opts.token;
@@ -193,7 +194,7 @@ PlexAPI.prototype._generateRelativeUrl = function _generateRelativeUrl(relativeU
 };
 
 PlexAPI.prototype._serverScheme = function _serverScheme() {
-    return this.port === 443 ? 'https://' : 'http://';
+    return this.port === 443 || this.https ? 'https://' : 'http://';
 };
 
 function filterChildrenByCriterias(children, criterias) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -18,7 +18,7 @@ function PlexAPI(options, deprecatedPort) {
 
     this.hostname = hostname;
     this.port = deprecatedPort || opts.port || PLEX_SERVER_PORT;
-    this.https = opts.https || false;
+    this.https = opts.https;
     this.username = opts.username;
     this.password = opts.password;
     this.authToken = opts.token;
@@ -194,7 +194,12 @@ PlexAPI.prototype._generateRelativeUrl = function _generateRelativeUrl(relativeU
 };
 
 PlexAPI.prototype._serverScheme = function _serverScheme() {
-    return this.port === 443 || this.https ? 'https://' : 'http://';
+    if (typeof this.https !== 'undefined') {
+        // If https is supplied by the user, always do what it says
+        return this.https ? 'https://' : 'http://';
+    }
+    // Otherwise, use https if it's on port 443, the standard https port.
+    return this.port === 443 ? 'https://' : 'http://';
 };
 
 function filterChildrenByCriterias(children, criterias) {

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -15,4 +15,8 @@ describe('_serverScheme', function() {
         var api = new PlexAPI({hostname: 'localhost', https: true});
         expect(api._serverScheme()).to.equal('https://');
     });
+    it('should use http when the https parameter is false, even on port 443', function() {
+        var api = new PlexAPI({hostname: 'localhost', port: 443, https: false});
+        expect(api._serverScheme()).to.equal('http://');
+    });
 });

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,0 +1,18 @@
+var expect = require('expect.js');
+
+var PlexAPI = require('..');
+
+describe('_serverScheme', function() {
+    it('should use http by default', function() {
+        var api = new PlexAPI({hostname: 'localhost'});
+        expect(api._serverScheme()).to.equal('http://');
+    });
+    it('should use https when port 443 is specified', function() {
+        var api = new PlexAPI({hostname: 'localhost', port: 443});
+        expect(api._serverScheme()).to.equal('https://');
+    });
+    it('should use https when the https parameter is true', function() {
+        var api = new PlexAPI({hostname: 'localhost', https: true});
+        expect(api._serverScheme()).to.equal('https://');
+    });
+});


### PR DESCRIPTION
Backwards compatible!

This is necessary for connecting directly to plex media servers securely when they are running not on port 443 (which is always). I have tested this is an actual app and it works :)

There is a teeny tiny corner case issue which I think is acceptable for the sake of backwards compatibility: if you supply both `port: 443` and `https: false`, it will still use https due to the port number. I can't imagine this will ever come up in a legitimate scenario though.