### PR TITLE
Add support for extra headers in all of the query() related methods

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,9 +31,13 @@ Here's an example of what an app shows up as on the Plex web interface
 
 The rows in that example from top to bottom are `deviceName`, `version`, `product`, and `device`.
 
-### .query(uri)
+### .query(parameters)
 
 **Retrieve content from URI**
+
+The parameter can be a string representing the URI, or an object with the following properties (everything is optional after the uri):
+- **uri**: the URI to query
+- **extraHeaders**: an object with extra headers to send in the HTTP request. Useful for things like X-Plex-Target-Client-Identifier
 
 Aside from requesting the API and returning its response, an `.uri` property are created to easier follow the URIs available in the HTTP API. At the moment URIs are attached for Directory and Server items.
 
@@ -54,13 +58,13 @@ client.query("/").then(function (result) {
 });
 ```
 
-### .postQuery(uri)
+### .postQuery(parameters)
 
 **Send a POST request and retrieve the response**
 
-This is identical to ```query(uri)```, except that the request will be a POST rather than a GET.
+This is identical to `query()`, except that the request will be a POST rather than a GET. It has the same required and optional parameters as `query()`.
 
-Note that the parameters can only be passed as a query string as part of the uri, which is all Plex requires. (```Content-Length``` will always be zero)
+Note that the parameters can only be passed as a query string as part of the uri, which is all Plex requires. (`Content-Length` will always be zero)
 
 ```js
 var PlexAPI = require("plex-api");
@@ -78,12 +82,13 @@ client.postQuery("/playQueue?type=video&uri=someuri&shuffle=0'").then(function (
 });
 ```
 
-### .perform(uri)
+### .perform(parameters)
 
 **Perform an API action**
 
 When performing an "action" on the HTTP API, the response body will be empty.
 As the response content itself is worthless, `perform()` acts on the HTTP status codes the server responds with.
+It has the same required and optional parameters as `query()`.
 
 ```js
 var PlexAPI = require("plex-api");
@@ -97,11 +102,11 @@ client.perform("/library/sections/1/refresh").then(function () {
 });
 ```
 
-### .find(uri, [{criterias}])
+### .find(parameters, [{criterias}])
 
 **Find matching child items on URI**
 
-Uses `query()` behind the scenes, giving all directories and servers the beloved `.uri` property.
+Uses `query()` behind the scenes, giving all directories and servers the beloved `.uri` property. It has the same required and optional parameters as `query`, in addition to a second optional `criterias` parameter.
 
 ```js
 var PlexAPI = require("plex-api");

--- a/Readme.md
+++ b/Readme.md
@@ -35,9 +35,9 @@ The rows in that example from top to bottom are `deviceName`, `version`, `produc
 
 **Retrieve content from URI**
 
-The parameter can be a string representing the URI, or an object with the following properties (everything is optional after the uri):
+The parameter can be a string representing the URI, or an object with the following properties:
 - **uri**: the URI to query
-- **extraHeaders**: an object with extra headers to send in the HTTP request. Useful for things like X-Plex-Target-Client-Identifier
+- (optional) **extraHeaders**: an object with extra headers to send in the HTTP request. Useful for things like X-Plex-Target-Client-Identifier
 
 Aside from requesting the API and returning its response, an `.uri` property are created to easier follow the URIs available in the HTTP API. At the moment URIs are attached for Directory and Server items.
 

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ Here's an example of what an app shows up as on the Plex web interface
 
 The rows in that example from top to bottom are `deviceName`, `version`, `product`, and `device`.
 
-### .query(parameters)
+### .query(options)
 
 **Retrieve content from URI**
 
@@ -58,7 +58,7 @@ client.query("/").then(function (result) {
 });
 ```
 
-### .postQuery(parameters)
+### .postQuery(options)
 
 **Send a POST request and retrieve the response**
 
@@ -82,7 +82,7 @@ client.postQuery("/playQueue?type=video&uri=someuri&shuffle=0'").then(function (
 });
 ```
 
-### .perform(parameters)
+### .perform(options)
 
 **Perform an API action**
 
@@ -102,7 +102,7 @@ client.perform("/library/sections/1/refresh").then(function () {
 });
 ```
 
-### .find(parameters, [{criterias}])
+### .find(options, [{criterias}])
 
 **Find matching child items on URI**
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -5,6 +5,7 @@ var request = require('request');
 var Q = require('q');
 var xml2js = require('xml2js');
 var headers = require('plex-api-headers');
+var extend = require('util')._extend;
 
 var xmlToJSON = Q.denodeify(xml2js.parseString);
 
@@ -54,53 +55,85 @@ PlexAPI.prototype.getIdentifier = function getIdentifier() {
     return this.options.identifier;
 };
 
-PlexAPI.prototype.query = function query(url) {
-    if (url === undefined) {
-        throw new TypeError('Requires url argument');
+PlexAPI.prototype.query = function query(parameters) {
+    if(typeof parameters === 'string') {
+        // Support old method of only supplying a single `url` parameter
+        parameters = { uri: parameters }
+    }
+    if (parameters.uri === undefined) {
+        throw new TypeError('Requires uri parameter');
     }
 
-    return this._request(url, 'GET', true).then(uri.attach(url));
+    parameters.method = 'GET';
+    parameters.parseResponse = true;
+
+    return this._request(parameters).then(uri.attach(parameters.uri));
 };
 
-PlexAPI.prototype.postQuery = function query(url) {
-    if (url === undefined) {
-        throw new TypeError('Requires url argument');
+PlexAPI.prototype.postQuery = function query(parameters) {
+    if(typeof parameters === 'string') {
+        // Support old method of only supplying a single `url` parameter
+        parameters = { uri: parameters }
+    }
+    if (parameters.uri === undefined) {
+        throw new TypeError('Requires uri parameter');
     }
 
-    return this._request(url, 'POST', true).then(uri.attach(url));
+    parameters.method = 'POST';
+    parameters.parseResponse = true;
+
+    return this._request(parameters).then(uri.attach(url));
 };
 
-PlexAPI.prototype.perform = function perform(url) {
-    if (url === undefined) {
-        throw new TypeError('Requires url argument');
+PlexAPI.prototype.perform = function perform(parameters) {
+    if(typeof parameters === 'string') {
+        // Support old method of only supplying a single `url` parameter
+        parameters = { uri: parameters }
+    }
+    if (parameters.uri === undefined) {
+        throw new TypeError('Requires uri parameter');
     }
 
-    return this._request(url, 'GET', false);
+    parameters.method = 'GET';
+    parameters.parseResponse = false;
+
+    return this._request(parameters);
 };
 
-PlexAPI.prototype.find = function find(relativeUrl, criterias) {
-    if (relativeUrl === undefined) {
-        throw new TypeError('Requires url argument');
+PlexAPI.prototype.find = function find(parameters, criterias) {
+    if(typeof parameters === 'string') {
+        // Support old method of only supplying a single `url` parameter
+        parameters = { uri: parameters }
+    }
+    if (parameters.uri === undefined) {
+        throw new TypeError('Requires uri parameter');
     }
 
-    return this.query(relativeUrl).then(function (result) {
+    return this.query(parameters).then(function (result) {
         return filterChildrenByCriterias(result._children, criterias);
     });
 };
 
-PlexAPI.prototype._request = function _request(relativeUrl, method, parseResponse) {
+PlexAPI.prototype._request = function _request(parameters) {
+    var reqUrl = this._generateRelativeUrl(parameters.uri);
+    var method = parameters.method;
+    var parseResponse = parameters.parseResponse;
+    var extraHeaders = parameters.extraHeaders || {};
+
     var self = this;
     var deferred = Q.defer();
-    var reqUrl = this._generateRelativeUrl(relativeUrl);
+
+    var requestHeaders = headers(this, extend({
+        'Accept': 'application/json',
+        'X-Plex-Token': this.authToken,
+        'X-Plex-Username': this.username
+    }, extraHeaders));
+
     var reqOpts = {
-        url: url.parse(reqUrl),
+        uri: url.parse(reqUrl),
         encoding: null,
         method: method || 'GET',
-        headers: headers(this, {
-            'Accept': 'application/json',
-            'X-Plex-Token': this.authToken,
-            'X-Plex-Username': this.username
-        })
+        headers: requestHeaders
     };
 
     request(reqOpts, function onResponse(err, response, body) {
@@ -120,7 +153,7 @@ PlexAPI.prototype._request = function _request(relativeUrl, method, parseRespons
 
             return deferred.resolve(self._authenticate()
                 .then(function () {
-                    return self._request(relativeUrl, method, parseResponse);
+                    return self._request(parameters);
                 })
             );
         }

--- a/lib/api.js
+++ b/lib/api.js
@@ -56,9 +56,9 @@ PlexAPI.prototype.getIdentifier = function getIdentifier() {
 };
 
 PlexAPI.prototype.query = function query(parameters) {
-    if(typeof parameters === 'string') {
+    if (typeof parameters === 'string') {
         // Support old method of only supplying a single `url` parameter
-        parameters = { uri: parameters }
+        parameters = { uri: parameters };
     }
     if (parameters.uri === undefined) {
         throw new TypeError('Requires uri parameter');
@@ -71,9 +71,9 @@ PlexAPI.prototype.query = function query(parameters) {
 };
 
 PlexAPI.prototype.postQuery = function query(parameters) {
-    if(typeof parameters === 'string') {
+    if (typeof parameters === 'string') {
         // Support old method of only supplying a single `url` parameter
-        parameters = { uri: parameters }
+        parameters = { uri: parameters };
     }
     if (parameters.uri === undefined) {
         throw new TypeError('Requires uri parameter');
@@ -86,9 +86,9 @@ PlexAPI.prototype.postQuery = function query(parameters) {
 };
 
 PlexAPI.prototype.perform = function perform(parameters) {
-    if(typeof parameters === 'string') {
+    if (typeof parameters === 'string') {
         // Support old method of only supplying a single `url` parameter
-        parameters = { uri: parameters }
+        parameters = { uri: parameters };
     }
     if (parameters.uri === undefined) {
         throw new TypeError('Requires uri parameter');
@@ -101,9 +101,9 @@ PlexAPI.prototype.perform = function perform(parameters) {
 };
 
 PlexAPI.prototype.find = function find(parameters, criterias) {
-    if(typeof parameters === 'string') {
+    if (typeof parameters === 'string') {
         // Support old method of only supplying a single `url` parameter
-        parameters = { uri: parameters }
+        parameters = { uri: parameters };
     }
     if (parameters.uri === undefined) {
         throw new TypeError('Requires uri parameter');

--- a/lib/api.js
+++ b/lib/api.js
@@ -55,70 +55,70 @@ PlexAPI.prototype.getIdentifier = function getIdentifier() {
     return this.options.identifier;
 };
 
-PlexAPI.prototype.query = function query(parameters) {
-    if (typeof parameters === 'string') {
+PlexAPI.prototype.query = function query(options) {
+    if (typeof options === 'string') {
         // Support old method of only supplying a single `url` parameter
-        parameters = { uri: parameters };
+        options = { uri: options };
     }
-    if (parameters.uri === undefined) {
+    if (options.uri === undefined) {
         throw new TypeError('Requires uri parameter');
     }
 
-    parameters.method = 'GET';
-    parameters.parseResponse = true;
+    options.method = 'GET';
+    options.parseResponse = true;
 
-    return this._request(parameters).then(uri.attach(parameters.uri));
+    return this._request(options).then(uri.attach(options.uri));
 };
 
-PlexAPI.prototype.postQuery = function query(parameters) {
-    if (typeof parameters === 'string') {
+PlexAPI.prototype.postQuery = function query(options) {
+    if (typeof options === 'string') {
         // Support old method of only supplying a single `url` parameter
-        parameters = { uri: parameters };
+        options = { uri: options };
     }
-    if (parameters.uri === undefined) {
+    if (options.uri === undefined) {
         throw new TypeError('Requires uri parameter');
     }
 
-    parameters.method = 'POST';
-    parameters.parseResponse = true;
+    options.method = 'POST';
+    options.parseResponse = true;
 
-    return this._request(parameters).then(uri.attach(url));
+    return this._request(options).then(uri.attach(url));
 };
 
-PlexAPI.prototype.perform = function perform(parameters) {
-    if (typeof parameters === 'string') {
+PlexAPI.prototype.perform = function perform(options) {
+    if (typeof options === 'string') {
         // Support old method of only supplying a single `url` parameter
-        parameters = { uri: parameters };
+        options = { uri: options };
     }
-    if (parameters.uri === undefined) {
+    if (options.uri === undefined) {
         throw new TypeError('Requires uri parameter');
     }
 
-    parameters.method = 'GET';
-    parameters.parseResponse = false;
+    options.method = 'GET';
+    options.parseResponse = false;
 
-    return this._request(parameters);
+    return this._request(options);
 };
 
-PlexAPI.prototype.find = function find(parameters, criterias) {
-    if (typeof parameters === 'string') {
+PlexAPI.prototype.find = function find(options, criterias) {
+    if (typeof options === 'string') {
         // Support old method of only supplying a single `url` parameter
-        parameters = { uri: parameters };
+        options = { uri: options };
     }
-    if (parameters.uri === undefined) {
+    if (options.uri === undefined) {
         throw new TypeError('Requires uri parameter');
     }
 
-    return this.query(parameters).then(function (result) {
+    return this.query(options).then(function (result) {
         return filterChildrenByCriterias(result._children, criterias);
     });
 };
 
-PlexAPI.prototype._request = function _request(parameters) {
-    var reqUrl = this._generateRelativeUrl(parameters.uri);
-    var method = parameters.method;
-    var parseResponse = parameters.parseResponse;
-    var extraHeaders = parameters.extraHeaders || {};
+PlexAPI.prototype._request = function _request(options) {
+    var reqUrl = this._generateRelativeUrl(options.uri);
+    var method = options.method;
+    var parseResponse = options.parseResponse;
+    var extraHeaders = options.extraHeaders || {};
 
     var self = this;
     var deferred = Q.defer();
@@ -153,7 +153,7 @@ PlexAPI.prototype._request = function _request(parameters) {
 
             return deferred.resolve(self._authenticate()
                 .then(function () {
-                    return self._request(parameters);
+                    return self._request(options);
                 })
             );
         }

--- a/test/find-test.js
+++ b/test/find-test.js
@@ -18,10 +18,36 @@ describe('find()', function() {
 		expect(api.find).to.be.a('function');
 	});
 
-	it('requires url parameter', function() {
-		expect(function() {
-			api.find();
-		}).to.throwException('TypeError');
+	describe('parameters', function() {
+		it('requires url parameter', function() {
+			expect(function() {
+				api.find();
+			}).to.throwException('TypeError');
+		});
+
+		it('can accept url parameter as only parameter', function() {
+			return api.find('/').then(function(result) {
+				expect(result).to.be.an('object');
+			});
+		});
+
+		it('can accept url parameter as part of a parameter object', function() {
+			return api.find({uri: '/'}).then(function(result) {
+				expect(result).to.be.an('object');
+			});
+		});
+
+		it('uses extra headers passed in parameters', function() {
+			server.stop();
+			var nockServer = server.start({'reqheaders': {
+				'X-TEST-HEADER':'X-TEST-HEADER-VAL'
+			}});
+
+			return api.find({uri: '/', extraHeaders: {'X-TEST-HEADER':'X-TEST-HEADER-VAL'}}).then(function(result) {
+				expect(result).to.be.an('object');
+				nockServer.done();
+			});
+		});
 	});
 
 	it('should provide all child items found', function() {

--- a/test/perform-test.js
+++ b/test/perform-test.js
@@ -11,6 +11,7 @@ describe('perform()', function() {
 
 	beforeEach(function() {
 		server.start();
+		server.withoutContent();
 
 		api = new PlexAPI('localhost');
 	});
@@ -21,10 +22,32 @@ describe('perform()', function() {
 		expect(api.perform).to.be.a('function');
 	});
 
-	it('requires url parameter', function() {
-		expect(function() {
-			api.perform();
-		}).to.throwException('TypeError');
+	describe('parameters', function() {
+		it('requires url parameter', function() {
+			expect(function() {
+				api.perform();
+			}).to.throwException('TypeError');
+		});
+
+		it('can accept url parameter as only parameter', function() {
+			return api.perform('/');
+		});
+
+		it('can accept url parameter as part of a parameter object', function() {
+			return api.perform({uri: '/'});
+		});
+
+		it('uses extra headers passed in parameters', function() {
+			server.stop();
+			var nockServer = server.start({'reqheaders': {
+				'X-TEST-HEADER':'X-TEST-HEADER-VAL'
+			}});
+
+			return api.perform({uri: '/', extraHeaders: {'X-TEST-HEADER':'X-TEST-HEADER-VAL'}}).then(function(result) {
+				nockServer.done();
+				return result;
+			});
+		});
 	});
 
 	it('promise should fail when server responds with failure status code', function() {
@@ -35,7 +58,6 @@ describe('perform()', function() {
 	});
 
 	it('promise should succeed when request response status code is 200', function() {
-		server.withoutContent();
 		return api.perform(PERFORM_URL);
 	});
 

--- a/test/postQuery-test.js
+++ b/test/postQuery-test.js
@@ -9,7 +9,7 @@ describe('postQuery()', function() {
 	var api;
 
 	beforeEach(function() {
-		server.start();
+		server.expectsPost();
 
 		api = new PlexAPI('localhost');
 	});
@@ -20,10 +20,32 @@ describe('postQuery()', function() {
 		expect(api.postQuery).to.be.a('function');
 	});
 
-	it('requires url parameter', function() {
-		expect(function() {
-			api.postQuery();
-		}).to.throwException('TypeError');
+	describe('parameters', function() {
+		it('requires url parameter', function() {
+			expect(function() {
+				api.postQuery();
+			}).to.throwException('TypeError');
+		});
+
+		it('can accept url parameter as only parameter', function() {
+			return api.postQuery('/');
+		});
+
+		it('can accept url parameter as part of a parameter object', function() {
+			return api.postQuery({uri: '/'});
+		});
+
+		it('uses extra headers passed in parameters', function() {
+			server.stop();
+			var nockServer = server.expectsPost({'reqheaders': {
+				'X-TEST-HEADER':'X-TEST-HEADER-VAL'
+			}});
+
+			return api.postQuery({uri: '/', extraHeaders: {'X-TEST-HEADER':'X-TEST-HEADER-VAL'}}).then(function(result) {
+				nockServer.done();
+				return result;
+			});
+		});
 	});
 
 	it('promise should fail when server responds with failure status code', function() {
@@ -33,7 +55,6 @@ describe('postQuery()', function() {
 	});
 
 	it('promise should succeed when request response status code is 200', function() {
-		server.expectsPost();
 		return api.postQuery(ROOT_URL);
 	});
 
@@ -44,7 +65,6 @@ describe('postQuery()', function() {
 	});
 
 	it('should result in a POST request', function() {
-		server.expectsPost();
 		return api.postQuery(ROOT_URL);
 	});
 });

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -21,10 +21,36 @@ describe('query()', function() {
 		expect(api.query).to.be.a('function');
 	});
 
-	it('requires url parameter', function() {
-		expect(function() {
-			api.query();
-		}).to.throwException('TypeError');
+	describe('parameters', function() {
+		it('requires url parameter', function() {
+			expect(function() {
+				api.query();
+			}).to.throwException('TypeError');
+		});
+
+		it('can accept url parameter as only parameter', function() {
+			return api.query('/').then(function(result) {
+				expect(result).to.be.an('object');
+			});
+		});
+
+		it('can accept url parameter as part of a parameter object', function() {
+			return api.query({uri: '/'}).then(function(result) {
+				expect(result).to.be.an('object');
+			});
+		});
+
+		it('uses extra headers passed in parameters', function() {
+			server.stop();
+			var nockServer = server.start({'reqheaders': {
+				'X-TEST-HEADER':'X-TEST-HEADER-VAL'
+			}});
+
+			return api.query({uri: '/', extraHeaders: {'X-TEST-HEADER':'X-TEST-HEADER-VAL'}}).then(function(result) {
+				expect(result).to.be.an('object');
+				nockServer.done();
+			});
+		});
 	});
 
 	it('promise should fail when server fails', function(done) {

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -21,26 +21,26 @@ describe('query()', function() {
 		expect(api.query).to.be.a('function');
 	});
 
-	describe('parameters', function() {
-		it('requires url parameter', function() {
+	describe('options', function() {
+		it('requires url options', function() {
 			expect(function() {
 				api.query();
 			}).to.throwException('TypeError');
 		});
 
-		it('can accept url parameter as only parameter', function() {
+		it('can accept url option as only parameter', function() {
 			return api.query('/').then(function(result) {
 				expect(result).to.be.an('object');
 			});
 		});
 
-		it('can accept url parameter as part of a parameter object', function() {
+		it('can accept url option as part of an options object', function() {
 			return api.query({uri: '/'}).then(function(result) {
 				expect(result).to.be.an('object');
 			});
 		});
 
-		it('uses extra headers passed in parameters', function() {
+		it('uses extra headers passed in options', function() {
 			server.stop();
 			var nockServer = server.start({'reqheaders': {
 				'X-TEST-HEADER':'X-TEST-HEADER-VAL'


### PR DESCRIPTION
Required a bit of refactoring - all query() related methods now accept a single `parameters` object for better future expandability

Tests updated to check new and old functionality

Interested in hearing thoughts before I merge it in - it's actually a pretty small change, but the refactoring makes it a lot of changed lines!