### PR TITLE
Enabling gzip to fix a bug in some versions of PMS/PHT that silently fail when no Accept-Encoding header is sent

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -134,6 +134,7 @@ PlexAPI.prototype._request = function _request(options) {
         uri: url.parse(reqUrl),
         encoding: null,
         method: method || 'GET',
+        gzip: true,
         headers: requestHeaders
     };
 


### PR DESCRIPTION
Alright, here's a weird one. Definitely open to other ways to solve this.

After much gnashing of teeth and debugging, I finally solved a problem I was having getting playback commands working when using a PMS as a proxy. It was simple: if the Accept-Encoding header is absent, the command fails (even though it returns 200). If the header is there, no matter what the value, it works. This is clearly a bug in either PMS or Plex Home Theater.

One solution to this bug is super simple: have `request` use the gzip option, which adds the header. `request` then handles any gzipped content it might receive completely invisibly and so nothing else changes in our module or any end-user's code. According to the `request` docs, the only thing to watch out for is trying to access the body of data directly on the response object as it will be raw bytes, but we don't use that nor do we return it.

My thought is that this is the behavior that all web browsers have when using the API through the website, and it will fix the bug for anyone else that might run in to it, so it seems safe and convenient.