### PR TITLE
Fix undefined runtime error when authenticating

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -209,22 +209,19 @@ PlexAPI.prototype._request = function _request(options) {
 };
 
 PlexAPI.prototype._authenticate = function _authenticate() {
-    var self = this;
-    var deferred = Q.defer();
-
-    if (this.authToken) {
-        return deferred.reject(new Error('Permission denied even after attempted authentication :( Wrong username and/or password maybe?'));
-    }
-
-    this.authenticator.authenticate(this, function (err, token) {
-        if (err) {
-            return deferred.reject(new Error('Authentication failed, reason: ' + err.message));
+    return new Promise((resolve, reject) => {
+        if (this.authToken) {
+            return reject(new Error('Permission denied even after attempted authentication :( Wrong username and/or password maybe?'));
         }
-        self.authToken = token;
-        deferred.resolve();
-    });
 
-    return deferred.promise;
+        this.authenticator.authenticate(this, (err, token) => {
+            if (err) {
+                throw new Error('Authentication failed, reason: ' + err.message);
+            }
+            this.authToken = token;
+            resolve();
+        });
+    });
 };
 
 PlexAPI.prototype._credentialsAuthenticator = function _credentialsAuthenticator() {

--- a/test/authenticator-test.js
+++ b/test/authenticator-test.js
@@ -103,6 +103,20 @@ describe('Authenticator', function() {
             });
         });
 
+        it('rejects when providing token and server still responds with 401', function () {
+            scope = server.start({
+                statusCode: 401,
+                retryStatusCode: 401,
+                expectRetry: true
+            });
+
+            return api.query(ROOT_URL).then(function onSuccess(result) {
+                throw new Error('Query should not have succeeded!');
+            }, function onError() {
+                scope.done();
+            });
+        });
+
     });
 
     describe('default authenticator', function() {

--- a/test/server.js
+++ b/test/server.js
@@ -55,7 +55,7 @@ module.exports = {
 			scope
 				.get('/')
 				.matchHeader('X-Plex-Token', 'abc-pretend-to-be-token')
-				.reply(200, respondToRequest);
+				.reply(options.retryStatusCode || 200, respondToRequest);
 		}
 
 		return scope;


### PR DESCRIPTION
The main objective behind doing these changes are fixing `TypeError` thrown seen when authenticating. While digging it seems this was always failing with this runtime error when doing a second authentication request in a row, probably meaning the credentials are invalid.

Fixed by converting use of `Q` for promises, to native `Promise` since we've got that at our disposal now that we required Node.js v4.x.

Fixes https://github.com/phillipj/node-plex-api/issues/72

*Note for later: we should remove all use of `Q`, as we could do without it.*