### PR TITLE
Replace use of Q with native Promise

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -2,12 +2,9 @@ var os = require('os');
 var uuid = require('uuid');
 var url = require('url');
 var request = require('request');
-var Q = require('q');
 var xml2js = require('xml2js');
 var headers = require('plex-api-headers');
 var extend = require('util')._extend;
-
-var xmlToJSON = Q.denodeify(xml2js.parseString);
 
 var uri = require('./uri');
 
@@ -139,7 +136,6 @@ PlexAPI.prototype._request = function _request(options) {
     var parseResponse = options.parseResponse;
     var extraHeaders = options.extraHeaders || {};
     var self = this;
-    var deferred = Q.defer();
 
     var requestHeaders = headers(this, extend({
         'Accept': 'application/json',
@@ -156,56 +152,56 @@ PlexAPI.prototype._request = function _request(options) {
         headers: requestHeaders
     };
 
-    request(reqOpts, function onResponse(err, response, body) {
-        var resolveValue;
+    return new Promise((resolve, reject) => {
+        request(reqOpts, function onResponse(err, response, body) {
+            var resolveValue;
 
-        if (err) {
-            return deferred.reject(err);
-        }
-
-        resolveValue = body;
-
-        // 403 forbidden when managed user does not have sufficient permission
-        if (response.statusCode === 403) {
-            return deferred.reject(new Error('Plex Server denied request due to lack of managed user permissions!'));
-        }
-
-        // 401 unauthorized when authentication is required against the requested URL
-        if (response.statusCode === 401) {
-            if (self.authenticator === undefined) {
-                return deferred.reject(new Error('Plex Server denied request, you must provide a way to authenticate! ' +
-                    'Read more about plex-api authenticators on https://www.npmjs.com/package/plex-api#authenticators'));
+            if (err) {
+                return reject(err);
             }
 
-            return deferred.resolve(self._authenticate()
-                .then(function () {
-                    return self._request(options);
-                })
-            );
-        }
+            resolveValue = body;
 
-        if (response.statusCode < 200 || response.statusCode > 299) {
-            return deferred.reject(new Error('Plex Server didnt respond with a valid 2xx status code, response code: ' + response.statusCode));
-        }
+            // 403 forbidden when managed user does not have sufficient permission
+            if (response.statusCode === 403) {
+                return reject(new Error('Plex Server denied request due to lack of managed user permissions!'));
+            }
 
-        // prevent holding an open http agent connection by pretending to consume data,
-        // releasing socket back to the agent connection pool: http://nodejs.org/api/http.html#http_agent_maxsockets
-        response.on('data', function onData() {});
+            // 401 unauthorized when authentication is required against the requested URL
+            if (response.statusCode === 401) {
+                if (self.authenticator === undefined) {
+                    return reject(new Error('Plex Server denied request, you must provide a way to authenticate! ' +
+                        'Read more about plex-api authenticators on https://www.npmjs.com/package/plex-api#authenticators'));
+                }
 
-        if (!parseResponse) {
-            return deferred.resolve();
-        }
+                return resolve(self._authenticate()
+                    .then(function () {
+                        return self._request(options);
+                    })
+                );
+            }
 
-        if (response.headers['content-type'] === 'application/json') {
-            resolveValue = JSON.parse(body.toString('utf8'));
-        } else if (response.headers['content-type'].indexOf('xml') > -1) {
-            resolveValue = xmlToJSON(body.toString('utf8'), { attrkey: 'attributes' });
-        }
+            if (response.statusCode < 200 || response.statusCode > 299) {
+                return reject(new Error('Plex Server didnt respond with a valid 2xx status code, response code: ' + response.statusCode));
+            }
 
-        return deferred.resolve(resolveValue);
+            // prevent holding an open http agent connection by pretending to consume data,
+            // releasing socket back to the agent connection pool: http://nodejs.org/api/http.html#http_agent_maxsockets
+            response.on('data', function onData() {});
+
+            if (!parseResponse) {
+                return resolve();
+            }
+
+            if (response.headers['content-type'] === 'application/json') {
+                resolveValue = JSON.parse(body.toString('utf8'));
+            } else if (response.headers['content-type'].indexOf('xml') > -1) {
+                resolveValue = xmlToJSON(body.toString('utf8'), { attrkey: 'attributes' });
+            }
+
+            return resolve(resolveValue);
+        });
     });
-
-    return deferred.promise;
 };
 
 PlexAPI.prototype._authenticate = function _authenticate() {
@@ -256,6 +252,17 @@ PlexAPI.prototype._serverScheme = function _serverScheme() {
     // Otherwise, use https if it's on port 443, the standard https port.
     return this.port === 443 ? 'https://' : 'http://';
 };
+
+function xmlToJSON(str, options) {
+    return new Promise((resolve, reject) => {
+        xml2js.parseString(str, options, (err, jsonObj) => {
+            if (err) {
+                return reject(err);
+            }
+            resolve(jsonObj);
+        });
+    });
+}
 
 function filterChildrenByCriterias(children, criterias) {
     var context = {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "plex-api-credentials": "^3.0.0",
     "plex-api-headers": "1.1.0",
-    "q": "1.4.1",
     "request": "2.72.0",
     "uuid": "2.0.2",
     "xml2js": "0.4.16"

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -42,7 +42,7 @@ describe('Module API', function() {
 
 		server.start({ port: 32401 });
 
-		api.query(ROOT_URL).done(function(result) {
+		api.query(ROOT_URL).then(function(result) {
 			expect(result).to.be.an('object');
 			done();
 		});
@@ -77,7 +77,7 @@ describe('Module API', function() {
 			}
 		});
 
-		api.query(ROOT_URL).done(function(result) {
+		api.query(ROOT_URL).then(function(result) {
 			expect(result).to.be.an('object');
 			nockServer.done();
 		});

--- a/test/perform-test.js
+++ b/test/perform-test.js
@@ -79,7 +79,7 @@ describe('perform()', function() {
 
 	it('promise should fail when server responds with failure status code', function() {
 		server.fails();
-		return api.perform(PERFORM_URL).fail(function(err) {
+		return api.perform(PERFORM_URL).catch(function(err) {
 			expect(err).not.to.be(null);
 		});
 	});

--- a/test/postQuery-test.js
+++ b/test/postQuery-test.js
@@ -49,7 +49,7 @@ describe('postQuery()', function() {
 	});
 
 	it('promise should fail when server responds with failure status code', function() {
-        return api.postQuery(ROOT_URL).fail(function(err) {
+		return api.postQuery(ROOT_URL).catch(function(err) {
 			expect(err).not.to.be(null);
 		});
 	});

--- a/test/put-test.js
+++ b/test/put-test.js
@@ -49,7 +49,7 @@ describe('putQuery()', function() {
 	});
 
 	it('promise should fail when server responds with failure status code', function() {
-        return api.putQuery(ROOT_URL).fail(function(err) {
+		return api.putQuery(ROOT_URL).catch(function(err) {
 			expect(err).not.to.be(null);
 		});
 	});

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -58,7 +58,7 @@ describe('query()', function() {
 
 		api.query(ROOT_URL).then(function() {
 			done(Error('Shouldnt succeed!'));
-		}).fail(function(err) {
+		}).catch(function(err) {
 			expect(err).not.to.be(null);
 			done();
 		});


### PR DESCRIPTION
Now that we required Node.js 4.x or above, we've got native Promise support. These changes removes the use of the 3rd party promise library Q, as we don't have much use for extra promise goodies in this package, and it's seen to be better to be a lean package than having this dependency.

**BREAKING CHANGE** as the returned promises from plex-api instances will now be *native* Promise instances, rather than Q promise instances.

Refs the first Q -> native Promise change: https://github.com/phillipj/node-plex-api/commit/2ea75ce3f7d0d3c7e25f5d4768b1eb976edb687f