### PR TITLE
Fix npm warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "plex-api-credentials": "^3.0.0",
     "plex-api-headers": "1.1.0",
-    "request": "2.72.0",
+    "request": "2.79.0",
     "uuid": "2.0.2",
     "xml2js": "0.4.16"
   },


### PR DESCRIPTION
npm is giving these warnings on every `npm install`:

```
npm WARN deprecated node-uuid@1.4.7: use uuid module instead
npm WARN deprecated tough-cookie@2.2.2: ReDoS vulnerability parsing Set-Cookie https://nodesecurity.io/advisories/130
```

These dependencies are installed by the package `request`, and upgrading that package should fix it.