### PR TITLE
Reject instead of throw from Authentication failure

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -212,7 +212,7 @@ PlexAPI.prototype._authenticate = function _authenticate() {
 
         this.authenticator.authenticate(this, (err, token) => {
             if (err) {
-                throw new Error('Authentication failed, reason: ' + err.message);
+                return reject(new Error('Authentication failed, reason: ' + err.message));
             }
             this.authToken = token;
             resolve();


### PR DESCRIPTION
Resolves #81 to reject instead of throw an exception. 