### PR TITLE
Add deleteQuery function and updated tests for node version 7,8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: node_js
 node_js:
   - 4
   - 6
+  - 7
+  - 8

--- a/Readme.md
+++ b/Readme.md
@@ -112,7 +112,7 @@ client.putQuery("/library/sections/3/all?type=1&id=123&summary.value=updatedSumm
 	});
 ```
 
-### .putQuery(options)
+### .deleteQuery(options)
 
 **Send a DELETE request and retrieve the response**
 

--- a/Readme.md
+++ b/Readme.md
@@ -112,6 +112,27 @@ client.putQuery("/library/sections/3/all?type=1&id=123&summary.value=updatedSumm
 	});
 ```
 
+### .putQuery(options)
+
+**Send a DELETE request and retrieve the response**
+
+This is identical to `query()`, except that the request will be a DELETE rather than a GET. It has the same required and optional parameters as `query()`. It's is used to delete parts of your Plex library.
+
+Note this will also delete the media files on hard disk! This can be allowed or forbidden in the plex-media-server options.
+Returns status code 403 if delete is not allowed in the plex-media-server options.
+
+```js
+var PlexAPI = require("plex-api");
+var client = new PlexAPI("192.168.0.1");
+
+client.deleteQuery("/library/metadata/10001/media/2002")
+	.then(function () {
+		console.log("Media was successfully deleted");
+	}, function (err) {
+		console.error("Could not connect to server", err);
+	});
+```
+
 ### .perform(options)
 
 **Perform an API action**

--- a/lib/api.js
+++ b/lib/api.js
@@ -101,6 +101,21 @@ PlexAPI.prototype.putQuery = function putQuery(options) {
     return this._request(options).then(uri.attach(url));
 };
 
+PlexAPI.prototype.deleteQuery = function deleteQuery(options) {
+    if (typeof options === 'string') {
+        // Support old method of only supplying a single `url` parameter
+        options = { uri: options };
+    }
+    if (options.uri === undefined) {
+        throw new TypeError('Requires uri parameter');
+    }
+
+    options.method = 'DELETE';
+    options.parseResponse = false;
+
+    return this._request(options);
+};
+
 PlexAPI.prototype.perform = function perform(options) {
     if (typeof options === 'string') {
         // Support old method of only supplying a single `url` parameter
@@ -167,7 +182,12 @@ PlexAPI.prototype._request = function _request(options) {
 
             // 403 forbidden when managed user does not have sufficient permission
             if (response.statusCode === 403) {
-                return reject(new Error('Plex Server denied request due to lack of managed user permissions!'));
+                return reject(
+                    new Error(
+                        'Plex Server denied request due to lack of managed user permissions! ' +
+                            'In case of a delete request, delete content mustbe  allowed in plex-media-server options.'
+                    )
+                );
             }
 
             // 401 unauthorized when authentication is required against the requested URL

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "expect.js": "^0.3.1",
     "mocha": "^2.5.0",
-    "nock": "^8.0.0",
+    "nock": "^9.0.0",
     "prettier": "1.1.0",
     "proxyquire": "^1.7.3",
     "sinon": "^1.17.2"

--- a/test/deleteQuery-test.js
+++ b/test/deleteQuery-test.js
@@ -1,0 +1,94 @@
+var expect = require('expect.js');
+var server = require('./server');
+
+var ROOT_URL = '/';
+
+var PlexAPI = require('..');
+
+describe('deleteQuery()', function() {
+    var api;
+
+    beforeEach(function() {
+        server.expectsDelete();
+
+        api = new PlexAPI('localhost');
+    });
+
+    afterEach(server.stop);
+
+    it('should exist', function() {
+        expect(api.deleteQuery).to.be.a('function');
+    });
+
+    describe('parameters', function() {
+        it('requires url parameter', function() {
+            expect(function() {
+                api.deleteQuery();
+            }).to.throwException('TypeError');
+        });
+
+        it('can accept url parameter as only parameter', function() {
+            return api.deleteQuery('/');
+        });
+
+        it('can accept url parameter as part of a parameter object', function() {
+            return api.deleteQuery({ uri: '/' });
+        });
+
+        it('uses extra headers passed in parameters', function() {
+            server.stop();
+            var nockServer = server.expectsDelete({
+                reqheaders: {
+                    'X-TEST-HEADER': 'X-TEST-HEADER-VAL'
+                }
+            });
+
+            return api
+                .deleteQuery({ uri: '/', extraHeaders: { 'X-TEST-HEADER': 'X-TEST-HEADER-VAL' } })
+                .then(function(result) {
+                    nockServer.done();
+                    return result;
+                });
+        });
+    });
+
+    it('promise should fail when server responds with failure status code', function() {
+        return api.deleteQuery(ROOT_URL).catch(function(err) {
+            expect(err).not.to.be(null);
+        });
+    });
+
+    it('promise should succeed when request response status code is 200', function() {
+        return api.deleteQuery(ROOT_URL);
+    });
+
+    it('promise should succeed when request response status code is 204', function() {
+        server.stop();
+        server.expectsDelete({ statusCode: 204 });
+        return api.deleteQuery(ROOT_URL);
+    });
+
+    it('promise should fail when server response status code is 404', function() {
+        server.stop();
+        server.expectsDelete({ statusCode: 404 });
+        return api.deleteQuery(ROOT_URL).catch(function(err) {
+            expect(err).not.to.be(null);
+        });
+    });
+
+    it('after delete request server should respond with status code 404', function(done) {
+        api.deleteQuery(ROOT_URL).then(function(res) {
+            expect(res).to.be.undefined;
+
+            api.deleteQuery(ROOT_URL).catch(function(err) {
+                expect(err).not.to.be(null);
+                expect(err.statusCode).to.be(404);
+                done();
+            });
+        });
+    });
+
+    it('should result in a DELETE request', function() {
+        return api.deleteQuery(ROOT_URL);
+    });
+});

--- a/test/server.js
+++ b/test/server.js
@@ -99,6 +99,23 @@ module.exports = {
             .reply(options.statusCode || 200, respondToRequest);
     },
 
+    expectsDelete: function expectsDelete(options) {
+        options = options || {};
+        options.port = options.port || PLEX_SERVER_PORT;
+        options.contentType = options.contentType || 'text/html';
+        respondWith = null;
+
+        return nock('http://localhost:' + options.port, {
+            reqheaders: options.reqheaders
+        })
+            .defaultReplyHeaders({
+                'Content-Type': options.contentType
+            })
+            .filteringPath(replaceActualPathToRoot)
+            .delete('/')
+            .reply(options.statusCode || 200, respondToRequest);
+    },
+
     stop: function stop() {
         nock.cleanAll();
     },


### PR DESCRIPTION
I added travis tests for node version 7 and 8, version 8 required an update of nock to version 9 after that all tests passes again.
I implemented a deleteQuery() function which sends DELETE requests, similar to the put and post queries except that it will never return any content (state of the plex api at this moment).
If pull-request will approved i would like to see a new release and npm publish, thank you.