### PR TITLE
fixes -Cannot read property 'filter' of undefined-

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -141,7 +141,7 @@ PlexAPI.prototype.find = function find(options, criterias) {
     }
 
     return this.query(options).then(function(result) {
-        return filterChildrenByCriterias(result._children, criterias);
+        return filterChildrenByCriterias(result._children || result.MediaContainer.Server, criterias);
     });
 };
 


### PR DESCRIPTION
Using plex-control I'm getting the following error message:

```
Potentially unhandled rejection [1] TypeError: Cannot read property 'filter' of undefined
    at filterChildrenByCriterias (C:\Users\Zefau\Projects\plex\node_modules\plex-control\node_modules\plex-api\lib\api.js:309:21)
    at C:\Users\Zefau\Projects\plex\node_modules\plex-control\node_modules\plex-api\lib\api.js:144:16
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

This is due to the index `result._children`, which does not exist. Replacing it with `result.MediaContainer.Server` solves the problem.

Cheers
Zefau

