### PR TITLE
If Content-Type is missing, default to a UTF-8 string response

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -284,6 +284,8 @@ PlexAPI.prototype._serverScheme = function _serverScheme() {
 PlexAPI.prototype._defaultResponseParser = function _defaultResponseParser(response, body) {
     if (response.headers['content-type'] === 'application/json') {
         return Promise.resolve(body.toString('utf8')).then(JSON.parse);
+    } else if (!response.headers['content-type']) {
+        return Promise.resolve(body.toString('utf8'));
     } else if (response.headers['content-type'].indexOf('xml') > -1) {
         return xmlToJSON(body.toString('utf8'), {
             attrkey: 'attributes'


### PR DESCRIPTION
I'm using `node-plex-api` for a simple project to update Posters.

When doing a PUT to the `/library/metadata/n/poster` URL, the response does not have a `Content-Type`.

Its headers are just:

```
{ connection: 'close',
     'content-length': '40',
     'x-plex-protocol': '1.0',
     'cache-control': 'no-cache',
     date: 'Fri, 20 Dec 2019 02:32:54 GMT' }
```

As a result, the `_defaultResponseParser` bails when it expects a `Content-Type`:

```
plex-poster-optimizer/node_modules/plex-api/lib/api.js:285
    } else if (response.headers['content-type'].indexOf('xml') > -1) {
                                               ^

TypeError: Cannot read property 'indexOf' of undefined
    at PlexAPI._defaultResponseParser (/Users/nicjansma/src/plex-poster-optimizer/node_modules/plex-api/lib/api.js:285:48)
    at Request.onResponse [as _callback] (/Users/nicjansma/src/plex-poster-optimizer/node_modules/plex-api/lib/api.js:224:49)
    at Request.self.callback (/Users/nicjansma/src/plex-poster-optimizer/node_modules/request/request.js:185:22)
    at emitTwo (events.js:125:13)
    at Request.emit (events.js:213:7)
    at Request.<anonymous> (/Users/nicjansma/src/plex-poster-optimizer/node_modules/request/request.js:1161:10)
    at emitOne (events.js:115:13)
    at Request.emit (events.js:210:7)
    at IncomingMessage.<anonymous> (/Users/nicjansma/src/plex-poster-optimizer/node_modules/request/request.js:1083:12)
    at Object.onceWrapper (events.js:314:30)
```

Because of this line:

```
response.headers['content-type'].indexOf('xml')
```

This change simply assumes a UTF-8 string encoding if the `Content-Type` header is missing