### PR TITLE
Drop official support for Node.js 8 since it's end-of-life

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Supporting older versions of Node.js gets more and more painful for every day. Only maintained versions of Node.js is officially supported.

Worth mentioning this doesn't introduce use of features not included in Node.js 8 already, so it _might_ still work going forward, but we won't take that into consideration when doing future changes.

With that in mind, a major bump of the plex-api package is around the corner.