### PR TITLE
Fix find query selecting wrong children object

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -142,7 +142,7 @@ PlexAPI.prototype.find = function find(options, criterias) {
     }
 
     return this.query(options).then(function (result) {
-        var children = result._children || result.MediaContainer.Server || result.MediaContainer.Directory;
+        var children = result._children || result.MediaContainer.Server || result.MediaContainer.Directory || result.MediaContainer.Provider;
         return filterChildrenByCriterias(children, criterias);
     });
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -142,7 +142,7 @@ PlexAPI.prototype.find = function find(options, criterias) {
     }
 
     return this.query(options).then(function (result) {
-        var children = result._children || result.MediaContainer.Server;
+        var children = result._children || result.MediaContainer.Server || result.MediaContainer.Directory;
         return filterChildrenByCriterias(children, criterias);
     });
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -142,7 +142,7 @@ PlexAPI.prototype.find = function find(options, criterias) {
     }
 
     return this.query(options).then(function (result) {
-        var children = result._children || result.MediaContainer.Server || result.MediaContainer.Directory || result.MediaContainer.Provider;
+        var children = result._children || result.MediaContainer.Server || result.MediaContainer.Directory || result.MediaContainer.Provider || result.MediaContainer.Metadata;
         return filterChildrenByCriterias(children, criterias);
     });
 };


### PR DESCRIPTION
Fixes an issue where the `find` query breaks on new versions of Plex Server, where the assumed directories array is located under a different key.

I don't see a way to test different versions in this package so I didn't write any tests sorry.

tested on Plex Server version `1.21.3.4021-5a0a3e4b2`

Fixes this issue that myself and another person had.
https://github.com/phillipj/node-plex-api/issues/111